### PR TITLE
Meteor 1.0.4 Fix

### DIFF
--- a/counter.coffee
+++ b/counter.coffee
@@ -1,13 +1,18 @@
-counterCollection =  new Mongo.Collection('awwx_mongo_counter')
+getRawMongoCollection = (collectionName) ->
+  if MongoInternals?
+    MongoInternals.defaultRemoteCollectionDriver().mongo._getCollection(collectionName)
+  else
+    Meteor._RemoteCollectionDriver.mongo._getCollection(collectionName)
+
 
 getCounterCollection = ->
-  counterCollection.rawCollection()
+  getRawMongoCollection('awwx_mongo_counter')
 
 
 callCounter = (method, args...) ->
   Counters = getCounterCollection()
-  if Meteor.wrapAsync?
-    Meteor.wrapAsync(_.bind(Counters[method], Counters))(args...)
+  if Meteor._wrapAsync?
+    Meteor._wrapAsync(_.bind(Counters[method], Counters))(args...)
   else
     future = new (Npm.require(Npm.require('path').join('fibers', 'future')))()
     Counters[method].call(Counters, args..., future.resolver())

--- a/counter.coffee
+++ b/counter.coffee
@@ -1,18 +1,13 @@
-getRawMongoCollection = (collectionName) ->
-  if MongoInternals?
-    MongoInternals.defaultRemoteCollectionDriver().mongo._getCollection(collectionName)
-  else
-    Meteor._RemoteCollectionDriver.mongo._getCollection(collectionName)
-
+counterCollection =  new Mongo.Collection('awwx_mongo_counter')
 
 getCounterCollection = ->
-  getRawMongoCollection('awwx_mongo_counter')
+  counterCollection.rawCollection()
 
 
 callCounter = (method, args...) ->
   Counters = getCounterCollection()
-  if Meteor._wrapAsync?
-    Meteor._wrapAsync(_.bind(Counters[method], Counters))(args...)
+  if Meteor.wrapAsync?
+    Meteor.wrapAsync(_.bind(Counters[method], Counters))(args...)
   else
     future = new (Npm.require(Npm.require('path').join('fibers', 'future')))()
     Counters[method].call(Counters, args..., future.resolver())

--- a/package.js
+++ b/package.js
@@ -1,9 +1,13 @@
 Package.describe({
-  summary: "Atomic counters stored in MongoDB"
+  summary: "Atomic counters stored in MongoDB",
+  version : '0.0.2'
 });
 
 Package.on_use(function (api) {
+  api.versionsFrom('1.0.4');
+
   api.use(['coffeescript', 'mongo-livedata'], 'server');
+
   if (api.export) {
     api.export('incrementCounter', 'server');
     api.export('decrementCounter', 'server');

--- a/package.js
+++ b/package.js
@@ -1,13 +1,9 @@
 Package.describe({
-  summary: "Atomic counters stored in MongoDB",
-  version : '0.0.2'
+  summary: "Atomic counters stored in MongoDB"
 });
 
 Package.on_use(function (api) {
-  api.versionsFrom('1.0.4');
-
   api.use(['coffeescript', 'mongo-livedata'], 'server');
-
   if (api.export) {
     api.export('incrementCounter', 'server');
     api.export('decrementCounter', 'server');

--- a/package.js
+++ b/package.js
@@ -3,6 +3,8 @@ Package.describe({
 });
 
 Package.on_use(function (api) {
+  api.versionsFrom('1.0.4');
+  
   api.use(['coffeescript', 'mongo-livedata'], 'server');
   if (api.export) {
     api.export('incrementCounter', 'server');


### PR DESCRIPTION
This fix is necessary to support Meteor 1.0.4, it relied on a public document method `rawCollection` instead of privates one.

It would nice to make a new release of this package to avoid breaking Meteor applications up to 1.0.3 version.
